### PR TITLE
Add compatibility with TYPO3 12 and 13

### DIFF
--- a/Classes/Controller/MapController.php
+++ b/Classes/Controller/MapController.php
@@ -2,6 +2,15 @@
 
 namespace Brinkert\Cbgooglemaps\Controller;
 
+use Symfony\Component\Routing\RequestContext;
+use TYPO3\CMS\Core\Http\Request;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Mvc\Controller\ActionController;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Utility\DebuggerUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use Psr\Http\Message\ResponseInterface;
 use TYPO3\CMS\Core\Core\Environment;
 
 /**
@@ -12,7 +21,7 @@ use TYPO3\CMS\Core\Core\Environment;
  * @copyright           (c)2011-2020 Christian Brinkert / Tobi
  * @author              Christian Brinkert <christian.brinkert@googlemail.com>
  */
-class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
+class MapController extends ActionController
 {
 
     protected $ceData;
@@ -24,14 +33,23 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
     /**
      * Do some global initialization
      */
-    public function initializeAction()
+    public function initializeAction(): void
     {
         // store content element data to local property
-        $this->ceData = $this->configurationManager->getContentObject()->data;
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $configurationManager = GeneralUtility::makeInstance(ConfigurationManager::class);
+
+        // Check if the currentContentObject is available
+        $contentObject = $contentObjectRenderer->data;
+        if (is_array($contentObject) && isset($contentObject['data'])) {
+            $this->ceData = $contentObject['data'];
+        } elseif (is_object($contentObject) && property_exists($contentObject, 'data')) {
+            $this->ceData = $contentObject->data;
+        }
 
         // get extension typoscript
-        $this->settings = $this->configurationManager->getConfiguration(
-            \TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS,
+        $this->settings = $configurationManager->getConfiguration(
+            ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS,
             'Cbgooglemaps',
             'Quickgooglemap');
 
@@ -42,15 +60,15 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
         $this->filePath = $baseUri . '/typo3conf/ext/cbgooglemaps/';
 
         // set content object renderer
-        $this->cobj = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
-            'TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
+        $this->cobj = GeneralUtility::makeInstance(
+            ContentObjectRenderer::class);
     }
 
 
     /**
      * Create map content element to the frontend
      */
-    public function indexAction()
+    public function indexAction(): ResponseInterface
     {
         // add google or openstreetmap scripts/styles
         $this->addJsCss();
@@ -63,6 +81,7 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
 
         // assign map parameters to the view
         $this->view->assignMultiple($mapParameter);
+        return $this->htmlResponse();
     }
 
 
@@ -72,56 +91,46 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
      */
     private function getMapParameters()
     {
+        $contentObjectRenderer = GeneralUtility::makeInstance(ContentObjectRenderer::class);
+        $contentObject = $contentObjectRenderer->data;
 
         return [
             // assign uid of current content element
             'contentId' => ((
-                null != $this->ceData['uid']
-                    ? $this->ceData['uid']
-                    : rand(1, 999999)
-                ) . '_' . $this->configurationManager->getContentObject()->parentRecord['data']['uid']),
+                    $this->ceData['uid'] ?? rand(1, 999999)
+                ) . '_' . isset($contentObject->parentRecord['data']['uid'])),
             // map provider to build map: googleMaps or OpenStreetMap
             'mapProvider' => $this->settings['mapProvider'],
             // assign width and height of map
-            'width' => null != $this->ceData['width']
-                ? $this->ceData['width']
-                : (
+            'width' => $this->ceData['width'] ?? (
                 0 < (int)$this->settings['cbgmMapWidth']
                     ? $this->settings['cbgmMapWidth']
                     : $this->settings['display']['width']
                 ),
-            'height' => null != $this->ceData['height']
-                ? $this->ceData['height']
-                : (
+            'height' => $this->ceData['height'] ?? (
                 0 < (int)$this->settings['cbgmMapHeight']
                     ? $this->settings['cbgmMapHeight']
                     : $this->settings['display']['height']
                 ),
             // assign pin description text, to placed into info box
             'infoText' => urlencode(
-                null != $this->ceData['infoText']
-                    ? $this->ceData['infoText']
-                    : (
-                isset($this->settings['cbgmDescription'])
-                    ? $this->settings['cbgmDescription']
-                    : $this->settings['infoText']
-                )
+                (string) ($this->ceData['infoText'] ?? (
+                    $this->settings['cbgmDescription'] ?? $this->settings['infoText']
+                ))
             ),
             // assign auto open flag to the view
-            'openInfoBox' => isset($this->settings['cbgmAutoOpen'])
-                ? $this->settings['cbgmAutoOpen']
-                : $this->settings['infoTextOpen'],
+            'openInfoBox' => $this->settings['cbgmAutoOpen'] ?? $this->settings['infoTextOpen'],
             // assign deactivation of zooming by mousewheel
             'useScrollwheel' => $this->settings['options']['useScrollwheel'],
             // assign location (longitude and latitude) to the view
-            'latitude' => null != $this->ceData['latitude']
+            'latitude' => isset($this->ceData['latitude'])
                 ? (float)$this->ceData['latitude']
                 : (
                 isset($this->settings['cbgmLatitude'])
                     ? (float)$this->settings['cbgmLatitude']
                     : (float)$this->settings['latitude']
                 ),
-            'longitude' => null != $this->ceData['longitude']
+            'longitude' => isset($this->ceData['longitude'])
                 ? (float)$this->ceData['longitude']
                 : (
                 isset($this->settings['cbgmLongitude'])
@@ -129,7 +138,7 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
                     : (float)$this->settings['longitude']
                 ),
             // assign map zoom level to the view ,if given value is valid
-            'mapZoom' => null != $this->ceData['zoom']
+            'mapZoom' => isset($this->ceData['zoom'])
                 ? (int)$this->ceData['zoom']
                 : (
                 0 <= (int)$this->settings['cbgmScaleLevel'] && !empty($this->settings['cbgmScaleLevel'])
@@ -137,32 +146,32 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
                     : (int)$this->settings['display']['zoom']
                 ),
             // assign map type to the view, if given value is valid
-            'mapType' => null != $this->ceData['mapType'] && in_array((string)$this->ceData['mapType'],
-                preg_split("/[\s]*[,][\s]*/", $this->settings['valid']['mapTypes']))
+            'mapType' => isset($this->ceData['mapType']) && in_array($this->ceData['mapType'],
+                preg_split("/[\s]*[,][\s]*/", (string) $this->settings['valid']['mapTypes']))
                 ? $this->ceData['mapType']
                 : (
                 in_array((string)$this->settings['cbgmMapType'],
-                    preg_split("/[\s]*[,][\s]*/", $this->settings['valid']['mapTypes']))
+                    preg_split("/[\s]*[,][\s]*/", (string) $this->settings['valid']['mapTypes']))
                     ? $this->settings['cbgmMapType']
                     : $this->settings['display']['mapType']
                 ),
             // assign navigation controls to the view
-            'mapControl' => null != $this->ceData['navigationControl']
+            'mapControl' => isset($this->ceData['navigationControl'])
             && in_array((string)$this->ceData['navigationControl'],
-                preg_split("/[\s]*[,][\s]*/", $this->settings['valid']['navigationControl']))
+                preg_split("/[\s]*[,][\s]*/", (string) $this->settings['valid']['navigationControl']))
                 ? $this->ceData['navigationControl']
                 : (
                 in_array((string)$this->settings['cbgmNavigationControl'],
-                    preg_split("/[\s]*[,][\s]*/", $this->settings['valid']['navigationControl']))
+                    preg_split("/[\s]*[,][\s]*/", (string) $this->settings['valid']['navigationControl']))
                     ? $this->settings['cbgmNavigationControl']
                     : $this->settings['display']['navigationControl']
                 ),
             // assign icon if given by constant or typoscript
-            'icon' => null != $this->ceData['icon'] && file_exists(Environment::getPublicPath() . '/' . $this->ceData['icon'])
-                ? \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . '/' . $this->ceData['icon']
+            'icon' => isset($this->ceData['icon']) && file_exists(Environment::getPublicPath() . '/' . $this->ceData['icon'])
+                ? GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . '/' . $this->ceData['icon']
                 : (
                     !empty($this->settings['display']['icon']) && file_exists(Environment::getPublicPath() . '/' . $this->settings['display']['icon'])
-                        ? \TYPO3\CMS\Core\Utility\GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . '/' . $this->settings['display']['icon']
+                        ? GeneralUtility::getIndpEnv('TYPO3_REQUEST_HOST') . '/' . $this->settings['display']['icon']
                         : null
                 ),
             // add map styling default
@@ -182,7 +191,7 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
     private function getMapStyling()
     {
 
-        if (null != $this->ceData['mapStyling']
+        if (isset($this->ceData['mapStyling'])
             && file_exists(Environment::getPublicPath() . '/' . $this->ceData['mapStyling'])) {
             // assign map styling from content element
 
@@ -211,14 +220,14 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
      * Add some javascripts and css styles to the view
      * @return void
      */
-    private function addJsCss()
+    private function addJsCss(): void
     {
 
         // add google or openstreet map scripts and styles to the view
         if ('Google' == $this->settings['mapProvider']) {
 
             // build google maps uri
-            $googleMapsUri = preg_match('/^http/', $this->settings['googleapi']['uri'])
+            $googleMapsUri = preg_match('/^http/', (string) $this->settings['googleapi']['uri'])
                 ? $this->settings['googleapi']['uri']
                 : $this->filePath . $this->settings['googleapi']['uri'];
 
@@ -233,11 +242,11 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
 
         } else if ('MapBox' == $this->settings['mapProvider']) {
             // add mapbox js and css files
-            $mapboxJs = preg_match('/^http/', $this->settings['mapboxapi']['js'])
+            $mapboxJs = preg_match('/^http/', (string) $this->settings['mapboxapi']['js'])
                 ? $this->settings['mapboxapi']['js']
                 : $this->filePath . $this->settings['mapboxapi']['js'];
 
-            $mapboxCss = preg_match('/^http/', $this->settings['mapboxapi']['css'])
+            $mapboxCss = preg_match('/^http/', (string) $this->settings['mapboxapi']['css'])
                 ? $this->settings['mapboxapi']['css']
                 : $this->filePath . $this->settings['mapboxapi']['css'];
 
@@ -249,11 +258,11 @@ class MapController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionController
 
         } else {
             // add leaflet js and css files
-            $osmJs = preg_match('/^http/', $this->settings['osmapi']['js'])
+            $osmJs = preg_match('/^http/', (string) $this->settings['osmapi']['js'])
                 ? $this->settings['osmapi']['js']
                 : $this->filePath . $this->settings['osmapi']['js'];
 
-            $osmCss = preg_match('/^http/', $this->settings['osmapi']['css'])
+            $osmCss = preg_match('/^http/', (string) $this->settings['osmapi']['css'])
                 ? $this->settings['osmapi']['css']
                 : $this->filePath . $this->settings['osmapi']['css'];
 

--- a/Classes/Form/Element/GeoCodingButtonElement.php
+++ b/Classes/Form/Element/GeoCodingButtonElement.php
@@ -10,31 +10,35 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 class GeoCodingButtonElement extends AbstractFormElement
 {
 
-    public function render()
+    public function render(): array
     {
         /** @var ConfigurationManager $cm */
         $cm = GeneralUtility::makeInstance(ConfigurationManager::class);
         $ts = $cm->getConfiguration($cm::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
-        $settings = $ts['plugin.']['tx_cbgooglemaps.']['settings.'];
-        $i18n = $ts['plugin.']['tx_cbgooglemaps.']['_LOCAL_LANG.'];
-        $iso2 = $GLOBALS['BE_USER']->uc['lang'] . '.';
-        $btnLabels = isset($i18n[$iso2]) ? $i18n[$iso2] : $i18n['default.'];
+        if(isset($ts['plugin.']['tx_cbgooglemaps.'])) {
+            $settings = $ts['plugin.']['tx_cbgooglemaps.']['settings.'];
+            $i18n = $ts['plugin.']['tx_cbgooglemaps.']['_LOCAL_LANG.'];
+            $iso2 = $GLOBALS['BE_USER']->uc['lang'] . '.';
+            $btnLabels = isset($i18n[$iso2]) ? $i18n[$iso2] : $i18n['default.'];
 
-        $fieldset = '<div class="cbgm_geocoding">';
-        $fieldset .= '<input type="button" onclick="cbGooglemaps.doGeocoding(\'' . $this->data['databaseRow']['uid'] . '\',\''
-            . $settings['mapProvider'] . '\',\''
-            . $settings['mapboxapi.']['accessToken'] . '\')" value="'
-            . $btnLabels['btnGeocoding'] . '">';
-        $fieldset .= '<input type="button" onclick="cbGooglemaps.displayLocation(\'' . $this->data['databaseRow']['uid'] . '\',\''
-            . $settings['mapProvider'] . '\',\''
-            . $settings['mapboxapi.']['accessToken'] . '\')" value="'
-            . $btnLabels['btnDisplayMap'] . '">';
-        $fieldset .= '<div id="cbgm_previewLocation"></div>';
-        $fieldset .= '</div>';
+            $fieldset = '<div class="cbgm_geocoding">';
+            $fieldset .= '<input type="button" onclick="cbGooglemaps.doGeocoding(\'' . $this->data['databaseRow']['uid'] . '\',\''
+                . $settings['mapProvider'] . '\',\''
+                . $settings['mapboxapi.']['accessToken'] . '\')" value="'
+                . $btnLabels['btnGeocoding'] . '">';
+            $fieldset .= '<input type="button" onclick="cbGooglemaps.displayLocation(\'' . $this->data['databaseRow']['uid'] . '\',\''
+                . $settings['mapProvider'] . '\',\''
+                . $settings['mapboxapi.']['accessToken'] . '\')" value="'
+                . $btnLabels['btnDisplayMap'] . '">';
+            $fieldset .= '<div id="cbgm_previewLocation"></div>';
+            $fieldset .= '</div>';
 
 
-        $result = $this->initializeResultArray();
-        $result['html'] = $fieldset;
-        return $result;
+            $result = $this->initializeResultArray();
+            $result['html'] = $fieldset;
+            return $result;
+        } else {
+            return [];
+        }
     }
 }

--- a/Classes/Form/Element/JsLibrariesElement.php
+++ b/Classes/Form/Element/JsLibrariesElement.php
@@ -2,6 +2,7 @@
 
 namespace Brinkert\Cbgooglemaps\Form\Element;
 
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -9,51 +10,53 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
 class JsLibrariesElement extends AbstractFormElement
 {
-    public function render()
+    public function render(): array
     {
         /** @var ConfigurationManager $cm */
         $cm = GeneralUtility::makeInstance(ConfigurationManager::class);
         $ts = $cm->getConfiguration($cm::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
-//        $filePath = explode('typo3conf', ExtensionManagementUtility::extPath('cbgooglemaps'))[1];
         $filePath = 'EXT:cbgooglemaps/';
 
 //        die($filePath);
 
 
+        if(isset($ts['plugin.']['tx_cbgooglemaps.'])) {
+            $settings = $ts['plugin.']['tx_cbgooglemaps.']['settings.'];
 
-        $settings = $ts['plugin.']['tx_cbgooglemaps.']['settings.'];
+            $pageRenderer = GeneralUtility::makeInstance(PageRenderer::class);
+            // add own scripts for gmaps object and mapping functions
+            $pageRenderer->addJsFile($filePath . 'Resources/Public/JavaScript/class.gmaps.js',
+                'text/javascript', FALSE, FALSE, '', FALSE);
+            $pageRenderer->addJsFile($filePath . 'Resources/Public/JavaScript/class.geocoding.js',
+                'text/javascript', FALSE, FALSE, '', FALSE);
 
-        $pageRenderer = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
-        // add own scripts for gmaps object and mapping functions
-        $pageRenderer->addJsFile($filePath . 'Resources/Public/JavaScript/class.gmaps.js',
-            'text/javascript', FALSE, FALSE, '', FALSE);
-        $pageRenderer->addJsFile($filePath . 'Resources/Public/JavaScript/class.geocoding.js',
-            'text/javascript', FALSE, FALSE, '', FALSE);
-
-        // add map provider specific libraries
-        if ('Google' === $settings['mapProvider']) {
-            // build googlemaps library url with optional api key - if given
-            $googleMapsUri = $settings['googleapi.']['uri'];
-            if ($settings['googleapi.']['key'])
-                $googleMapsUri .= '?key=' . $settings['googleapi.']['key'];
-            // add google libraries
-            $pageRenderer->addJsFile($googleMapsUri, 'text/javascript', FALSE, FALSE, '', TRUE);
-        } else if ('MapBox' === $settings['mapProvider']) {
-            // add mapbox libraries
-            $pageRenderer->addJsFile(
-                $filePath . 'Resources/Public/JavaScript/mapbox/mapbox-gl-patched.js',
-                'text/javascript', FALSE, FALSE, '', TRUE);
-            $pageRenderer->addCssFile(
-                $filePath . 'Resources/Public/JavaScript/mapbox/mapbox-gl.css',
-                'stylesheet', 'all', '', FALSE, FALSE, '', TRUE);
-        } else {
-            // add openstreetmap libraries
-            $pageRenderer->addJsFile(
-                $filePath . 'Resources/Public/JavaScript/leaflet/leaflet-src-patched.js',
-                'text/javascript', FALSE, FALSE, '', TRUE);
-            $pageRenderer->addCssFile(
-                $filePath . 'Resources/Public/JavaScript/leaflet/leaflet.css',
-                'stylesheet', 'all', '', FALSE, FALSE, '', TRUE);
+            // add map provider specific libraries
+            if ('Google' === $settings['mapProvider']) {
+                // build googlemaps library url with optional api key - if given
+                $googleMapsUri = $settings['googleapi.']['uri'];
+                if ($settings['googleapi.']['key'])
+                    $googleMapsUri .= '?key=' . $settings['googleapi.']['key'];
+                // add google libraries
+                $pageRenderer->addJsFile($googleMapsUri, 'text/javascript', FALSE, FALSE, '', TRUE);
+            } else if ('MapBox' === $settings['mapProvider']) {
+                // add mapbox libraries
+                $pageRenderer->addJsFile(
+                    $filePath . 'Resources/Public/JavaScript/mapbox/mapbox-gl-patched.js',
+                    'text/javascript', FALSE, FALSE, '', TRUE);
+                $pageRenderer->addCssFile(
+                    $filePath . 'Resources/Public/JavaScript/mapbox/mapbox-gl.css',
+                    'stylesheet', 'all', '', FALSE, FALSE, '', TRUE);
+            } else {
+                // add openstreetmap libraries
+                $pageRenderer->addJsFile(
+                    $filePath . 'Resources/Public/JavaScript/leaflet/leaflet-src-patched.js',
+                    'text/javascript', FALSE, FALSE, '', TRUE);
+                $pageRenderer->addCssFile(
+                    $filePath . 'Resources/Public/JavaScript/leaflet/leaflet.css',
+                    'stylesheet', 'all', '', FALSE, FALSE, '', TRUE);
+            }
         }
+
+        return [];
     }
 }

--- a/Classes/Form/Element/PreviewButtonElement.php
+++ b/Classes/Form/Element/PreviewButtonElement.php
@@ -9,31 +9,34 @@ use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 class PreviewButtonElement extends AbstractFormElement
 {
 
-    public function render()
+    public function render(): array
     {
 
         /** @var ConfigurationManager $cm */
         $cm = GeneralUtility::makeInstance(ConfigurationManager::class);
         $ts = $cm->getConfiguration($cm::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
-        $settings = $ts['plugin.']['tx_cbgooglemaps.']['settings.'];
-        $i18n = $ts['plugin.']['tx_cbgooglemaps.']['_LOCAL_LANG.'];
-        $iso2 = $GLOBALS['BE_USER']->uc['lang'] . '.';
-        $btnLabels = isset($i18n[$iso2]) ? $i18n[$iso2] : $i18n['default.'];
+            if(isset($ts['plugin.']['tx_cbgooglemaps.'])) {
+                $settings = $ts['plugin.']['tx_cbgooglemaps.']['settings.'];
+                $i18n = $ts['plugin.']['tx_cbgooglemaps.']['_LOCAL_LANG.'];
+                $iso2 = $GLOBALS['BE_USER']->uc['lang'] . '.';
+                $btnLabels = isset($i18n[$iso2]) ? $i18n[$iso2] : $i18n['default.'];
+                $fieldset =  '<div class="cbgm_preview">';
+                $fieldset .= '<input type="button" onclick="cbGooglemaps.displayPreview(\''
+                    . $this->data['vanillaUid'].'\',\''
+                    . $settings['display.']['zoom'].'\',\''
+                    . $settings['display.']['mapType'].'\',\''
+                    . $settings['display.']['navigationControl'].'\',\''
+                    . $settings['mapProvider'] .'\',\''
+                    . $settings['mapboxapi.']['accessToken'] .'\')" value="'
+                    . $btnLabels['btnPreviewMap'] .'">';
+                $fieldset .= '<div id="cbgm_previewMap"></div>';
+                $fieldset .= '</div>';
 
-        $fieldset =  '<div class="cbgm_preview">';
-        $fieldset .= '<input type="button" onclick="cbGooglemaps.displayPreview(\''
-            . $this->data['vanillaUid'].'\',\''
-            . $settings['display.']['zoom'].'\',\''
-            . $settings['display.']['mapType'].'\',\''
-            . $settings['display.']['navigationControl'].'\',\''
-            . $settings['mapProvider'] .'\',\''
-            . $settings['mapboxapi.']['accessToken'] .'\')" value="'
-            . $btnLabels['btnPreviewMap'] .'">';
-        $fieldset .= '<div id="cbgm_previewMap"></div>';
-        $fieldset .= '</div>';
-
-        $result = $this->initializeResultArray();
-        $result['html'] = $fieldset;
-        return $result;
+            $result = $this->initializeResultArray();
+            $result['html'] = $fieldset;
+            return $result;
+        } else {
+            return [];
+        }
     }
 }

--- a/Configuration/FlexForms/flexform_quickgooglemap.xml
+++ b/Configuration/FlexForms/flexform_quickgooglemap.xml
@@ -6,21 +6,17 @@
     <sheets>
         <sDEF>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.sheetLocation</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.sheetLocation</sheetTitle>
                 <type>array</type>
                 <el>
                     <settings.cbgmIncludeJs>
-                        <TCEforms>
                             <config>
                                 <type>user</type>
                                 <renderType>jsLibrariesElement</renderType>
                             </config>
-                        </TCEforms>
                     </settings.cbgmIncludeJs>
+
                     <settings.cbgmStreet>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.street</label>
                             <config>
                                 <type>input</type>
@@ -28,10 +24,9 @@
                                 <max>40</max>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmStreet>
+
                     <settings.cbgmZip>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.zip</label>
                             <config>
                                 <type>input</type>
@@ -39,10 +34,9 @@
                                 <max>10</max>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmZip>
+
                     <settings.cbgmCity>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.city</label>
                             <config>
                                 <type>input</type>
@@ -50,10 +44,9 @@
                                 <max>40</max>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmCity>
+
                     <settings.cbgmCountry>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.country</label>
                             <config>
                                 <type>input</type>
@@ -61,19 +54,17 @@
                                 <max>60</max>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmCountry>
+
                     <cbgmButtonGeocoding>
-                        <TCEforms>
                             <label></label>
                             <config>
                                 <type>user</type>
                                 <renderType>geoCodingButtonElement</renderType>
                             </config>
-                        </TCEforms>
                     </cbgmButtonGeocoding>
+
                     <settings.cbgmLatitude>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.latitude</label>
                             <config>
                                 <type>input</type>
@@ -81,10 +72,9 @@
                                 <max>25</max>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmLatitude>
+
                     <settings.cbgmLongitude>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.longitude</label>
                             <config>
                                 <type>input</type>
@@ -92,20 +82,17 @@
                                 <max>25</max>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmLongitude>
                 </el>
             </ROOT>
         </sDEF>
+
         <s_displayproperties>
             <ROOT>
-                <TCEforms>
-                    <sheetTitle>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.sheetDisplay</sheetTitle>
-                </TCEforms>
+                <sheetTitle>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.sheetDisplay</sheetTitle>
                 <type>array</type>
                 <el>
                     <settings.cbgmDescription>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.description</label>
                             <config>
                                 <type>text</type>
@@ -113,19 +100,17 @@
                                 <rows>10</rows>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmDescription>
+
                     <settings.cbgmAutoOpen>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.autoOpen</label>
                             <config>
                                 <type>check</type>
                                 <default>0</default>
                             </config>
-                        </TCEforms>
                     </settings.cbgmAutoOpen>
+
                     <settings.cbgmMapWidth>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.mapWidth</label>
                             <config>
                                 <type>input</type>
@@ -133,10 +118,9 @@
                                 <max>5</max>
                                 <eval>trim</eval>
                             </config>
-                        </TCEforms>
                     </settings.cbgmMapWidth>
+
                     <settings.cbgmMapHeight>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.mapHeight</label>
                             <config>
                                 <type>input</type>
@@ -145,10 +129,9 @@
                                 <eval>trim</eval>
                                 <default>250</default>
                             </config>
-                        </TCEforms>
                     </settings.cbgmMapHeight>
+
                     <settings.cbgmScaleLevel>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.scaleLevel</label>
                             <config>
                                 <type>input</type>
@@ -157,10 +140,9 @@
                                 <max>3</max>
                                 <default>12</default>
                             </config>
-                        </TCEforms>
                     </settings.cbgmScaleLevel>
+
                     <settings.cbgmMapType>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.mapType</label>
                             <config>
                                 <type>select</type>
@@ -213,10 +195,9 @@
                                     </numIndex>
                                 </items>
                             </config>
-                        </TCEforms>
                     </settings.cbgmMapType>
+
                     <settings.cbgmNavigationControl>
-                        <TCEforms>
                             <label>LLL:EXT:cbgooglemaps/Resources/Private/Language/locallang.xlf:label.navigationControl</label>
                             <config>
                                 <type>select</type>
@@ -245,17 +226,14 @@
                                     </numIndex>
                                 </items>
                             </config>
-                        </TCEforms>
                     </settings.cbgmNavigationControl>
 
                     <cbgmButtonGeocoding>
-                        <TCEforms>
                             <label></label>
                             <config>
                                 <type>user</type>
                                 <renderType>previewButtonElement</renderType>
                             </config>
-                        </TCEforms>
                     </cbgmButtonGeocoding>
                 </el>
             </ROOT>

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,9 @@
+services:
+  # Place here the default dependency injection configuration
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: true
+
+  Brinkert\Cbgooglemaps\:
+    resource: '../Classes/*'

--- a/Configuration/page.tsconfig
+++ b/Configuration/page.tsconfig
@@ -1,0 +1,1 @@
+@import 'EXT:cbgooglemaps/Configuration/TsConfig/ContentElementWizard.tsconfig'

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "license": ["GPL-2.0-or-later"],
   "require": {
-    "typo3/cms-core": "^8.7.13 || >=9.0.0 < 10.9.99 || ^11.1"
+    "typo3/cms-core": "^12.4 || ^13.4"
   },
   "autoload": {
     "psr-4": {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -5,29 +5,25 @@ defined('TYPO3') or die();
 
 // encapsulate all locally defined variables
 (static function() {
-    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig(
-        '<INCLUDE_TYPOSCRIPT: source="FILE:EXT:cbgooglemaps/Configuration/TsConfig/ContentElementWizard.tsconfig">'
-    );
-    
     $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
-    
+
     $iconRegistry->registerIcon(
         'ce-default-icon',
         \TYPO3\CMS\Core\Imaging\IconProvider\SvgIconProvider::class,
         ['source' => 'EXT:cbgooglemaps/Resources/Public/Icons/ce_wiz.svg']
     );
-    
+
     \TYPO3\CMS\Extbase\Utility\ExtensionUtility::configurePlugin(
         'cbgooglemaps',
         'Quickgooglemap',
         [
             \Brinkert\Cbgooglemaps\Controller\MapController::class => 'index',
         ],
-    
+
         // non-cacheable actions
         []
     );
-    
+
     $tStamp = (new Datetime("now"))->getTimestamp();
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][$tStamp] = [
         'nodeName' => 'previewButtonElement',


### PR DESCRIPTION
This update ensures the cbgooglemaps extension is fully compatible with TYPO3 versions 12 and 13. The following changes have been made:

- **PHP 8 Compatibility**: Prevented warnings related to potentially unset variables.
- **Deprecations**: Fixed several deprecations, with particular attention to the MapController.
- **Flexform Fixes**: Updated the deprecated <TCEform> tag in the Flexform configuration.
- **File Structure Update**: Added a page.tsconfig file to match the current TYPO3 file structure conventions.
- **Service Configuration**: Included a Services.yaml file for proper class wiring in TYPO3 v12 and v13.
- **Bumped version**

If some issues occur, feel free to comment or add your code.
Cheers!